### PR TITLE
Fmi3 beta (#16)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FMICore"
 uuid = "8af89139-c281-408e-bce2-3005eb87462f"
 authors = ["TT <tobias.thummerer@informatik.uni-augsburg.de>", "LM <lars.mikelsons@informatik.uni-augsburg.de>", "JK <josef.kircher@student.uni-augsburg.de>"]
-version = "0.8.4"
+version = "0.9.0"
 
 [compat]
 julia = "^1.5"

--- a/src/FMI2.jl
+++ b/src/FMI2.jl
@@ -155,6 +155,7 @@ FMU states:     $(c.x)"
 )
 
 """
+=======
 A mutable struct representing the excution configuration of a FMU.
 For FMUs that have issues with calls like `fmi2Reset` or `fmi2FreeInstance`, this is pretty useful.
 """
@@ -406,7 +407,7 @@ mutable struct FMU2 <: FMU
     zipPath::String
 
     # execution configuration
-    executionConfig::FMU2ExecutionConfiguration
+    executionConfig::FMUExecutionConfiguration
     hasStateEvents::Union{Bool, Nothing} 
     hasTimeEvents::Union{Bool, Nothing} 
 

--- a/src/FMI2_c.jl
+++ b/src/FMI2_c.jl
@@ -154,7 +154,7 @@ const fmi2TypeCoSimulation  = Cuint(1)
 mutable struct fmi2ModelDescriptionReal 
     # mandatory
     # (nothing)
-    
+
     # optional
     declaredType::Union{String, Nothing}
     quantity::Union{String, Nothing}

--- a/src/FMI3.jl
+++ b/src/FMI3.jl
@@ -4,15 +4,48 @@
 #
 
 # What is included in this file:
-# - the `fmi3ComponentState`-enum which mirrors the internal FMU state (state-machine, not the system state)
-# - the `FMU3Component`-struct 
+# - the `fmi3InstanceState`-enum which mirrors the internal FMU state (state-machine, not the system state)
+# - the `FMU3Instance`-struct 
 # - the `FMU3`-struct
 # - string/enum-converters for FMI-attribute-structs (e.g. `fmi3StatusToString`, ...)
 
-# this is a custom type to catch the internal state of the component 
-@enum fmi3ComponentState begin
-    # ToDo
-    fmi3ComponentToDo
+# this is a custom type to catch the internal state of the instance
+
+@enum fmi3InstanceState begin
+    fmi3InstanceStateInstantiated       # after instantiation
+    fmi3InstanceStateInitializationMode # after finishing initialization
+    fmi3InstanceStateEventMode
+    fmi3InstanceStateStepMode
+    fmi3InstanceStateClockActivationMode
+    fmi3InstanceStateContinuousTimeMode
+    fmi3InstanceStateConfigurationMode
+    fmi3InstanceStateReconfigurationMode
+    fmi3InstanceStateTerminated 
+    fmi3InstanceStateError 
+    fmi3InstanceStateFatal
+end
+
+"""
+ToDo.
+"""
+mutable struct FMU3InstanceEnvironment
+    logStatusOK::Bool
+    logStatusWarning::Bool
+    logStatusDiscard::Bool
+    logStatusError::Bool
+    logStatusFatal::Bool
+    logStatusPending::Bool
+
+    function FMU3InstanceEnvironment()
+        inst = new()
+        inst.logStatusOK = true
+        inst.logStatusWarning = true
+        inst.logStatusDiscard = true
+        inst.logStatusError = true
+        inst.logStatusFatal = true
+        inst.logStatusPending = true
+        return inst
+    end
 end
 
 """
@@ -20,18 +53,21 @@ Source: FMISpec3.0, Version D5ef1c1:: 2.2.1. Header Files and Naming of Function
 
 The mutable struct represents a pointer to an FMU specific data structure that contains the information needed to process the model equations or to process the co-simulation of the model/subsystem represented by the FMU.
 """
-mutable struct FMU3Component
+mutable struct FMU3Instance
     compAddr::Ptr{Nothing}
-    fmu
-    state 
-    
+    fmu # ::FMU3
+    state::fmi3InstanceState
+    instanceEnvironment::FMU3InstanceEnvironment
+
     loggingOn::Bool
     instanceName::String
     continuousStatesChanged::fmi3Boolean
 
     t::fmi3Float64             # the system time
-    #x::Array{fmi3Float64, 1}   # the system states (or sometimes u)
-    #ẋ::Array{fmi3Float64, 1}   # the system state derivative (or sometimes u̇)
+    t_offset::fmi3Float64      # time offset between simulation environment and FMU
+    x::Union{Array{fmi3Float64, 1}, Nothing}   # the system states (or sometimes u)
+    ẋ::Union{Array{fmi3Float64, 1}, Nothing}   # the system state derivative (or sometimes u̇)
+    ẍ::Union{Array{fmi3Float64, 1}, Nothing}   # the system state second derivative
     #u::Array{fmi3Float64, 1}   # the system inputs
     #y::Array{fmi3Float64, 1}   # the system outputs
     #p::Array{fmi3Float64, 1}   # the system parameters
@@ -46,13 +82,22 @@ mutable struct FMU3Component
     y_vrs::Array{fmi3ValueReference, 1}   # the system output value references
     p_vrs::Array{fmi3ValueReference, 1}   # the system parameter value references
 
-    # FMIFlux 
-
-    jac_dxy_x::Matrix{fmi3Float64}
-    jac_dxy_u::Matrix{fmi3Float64}
+    # deprecated
+    jac_ẋy_x::Matrix{fmi3Float64}
+    jac_ẋy_u::Matrix{fmi3Float64}
     jac_x::Array{fmi3Float64}
+    jac_u::Union{Array{fmi3Float64}, Nothing}
     jac_t::fmi3Float64
+
+    # linearization jacobians
+    A::Union{Matrix{fmi3Float64}, Nothing}
+    B::Union{Matrix{fmi3Float64}, Nothing}
+    C::Union{Matrix{fmi3Float64}, Nothing}
+    D::Union{Matrix{fmi3Float64}, Nothing}
+
+    jacobianUpdate!             # function for a custom jacobian constructor (optimization)
     skipNextDoStep::Bool    # allows skipping the next `fmi2DoStep` like it is not called
+    senseFunc::Symbol       # :auto, :full, :sample, :directionalDerivatives, :adjointDerivatives
 
     # custom
 
@@ -61,40 +106,62 @@ mutable struct FMU3Component
     timeEvent::fmi3Boolean
     stepEvent::fmi3Boolean
 
-    function fmi3Component(compAddr, fmu)
-        inst = new()
-        inst.compAddr = compAddr
-        inst.fmu = fmu
-        inst.t = 0.0
+    # constructor
 
+    function FMU3Instance()
+        inst = new()
+        inst.state = fmi3InstanceStateInstantiated
+        inst.t = -Inf
+        inst.t_offset = 0.0
+
+        inst.senseFunc = :auto
+        
+        inst.x = nothing
+        inst.ẋ = nothing
+        inst.ẍ = nothing
         inst.z_prev = nothing
 
         inst.realValues = Dict()
-        inst.x_vrs = Array{fmi3ValueReference, 1}()
-        inst.ẋ_vrs = Array{fmi3ValueReference, 1}() 
-        inst.u_vrs = Array{fmi3ValueReference, 1}()  
-        inst.y_vrs = Array{fmi3ValueReference, 1}()  
-        inst.p_vrs = Array{fmi3ValueReference, 1}() 
+        inst.x_vrs = Array{fmi2ValueReference, 1}()
+        inst.ẋ_vrs = Array{fmi2ValueReference, 1}() 
+        inst.u_vrs = Array{fmi2ValueReference, 1}()  
+        inst.y_vrs = Array{fmi2ValueReference, 1}()  
+        inst.p_vrs = Array{fmi2ValueReference, 1}() 
 
         # initialize further variables 
         inst.jac_x = Array{fmi3Float64, 1}()
+        inst.jac_u = nothing
         inst.jac_t = -1.0
-        inst.jac_dxy_x = zeros(fmi3Float64, 0, 0)
-        inst.jac_dxy_u = zeros(fmi3Float64, 0, 0)
+        inst.jac_ẋy_x = zeros(fmi3Float64, 0, 0)
+        inst.jac_ẋy_u = zeros(fmi3Float64, 0, 0)
         inst.skipNextDoStep = false
 
+        inst.A = nothing
+        inst.B = nothing
+        inst.C = nothing
+        inst.D = nothing
+        return inst
+    end
+
+    function FMU3Instance(compAddr, fmu)
+        inst = FMU3Instance()
+        inst.compAddr = compAddr
+        inst.fmu = fmu
         return inst
     end
 end
 
-""" Overload the Base.show() function for custom printing of the FMU2Component"""
-Base.show(io::IO, fmu::FMU3Component) = print(io,
-"FMU2:         $(fmu.fmu)
-State:         $(fmu.state)
-Logging:       $(fmu.loggingOn)
-Instance name: $(fmu.instanceName)
-System time:   $(fmu.t)
-Values:        $(fmu.realValues)"
+""" 
+Overload the Base.show() function for custom printing of the FMU2Component.
+"""
+Base.show(io::IO, c::FMU3Instance) = print(io,
+"FMU:            $(c.fmu.modelDescription.modelName)
+InstanceName:   $(isdefined(c, :instanceName) ? c.instanceName : "[not defined]")
+Address:        $(c.compAddr)
+State:          $(c.state)
+Logging:        $(c.loggingOn)
+FMU time:       $(c.t)
+FMU states:     $(c.x)"
 )
 
 """
@@ -112,7 +179,7 @@ mutable struct FMU3 <: FMU
 
     type::fmi3Type
     instanceEnvironment::fmi3InstanceEnvironment
-    components::Array # {fmi3Component}   
+    instances::Array # {fmi3Instance}   
 
     # c-functions
     cInstantiateModelExchange::Ptr{Cvoid}
@@ -196,26 +263,36 @@ mutable struct FMU3 <: FMU
 
     # paths of ziped and unziped FMU folders
     path::String
+    binaryPath::String
     zipPath::String
+
+    # execution configuration
+    executionConfig::FMUExecutionConfiguration
+    hasStateEvents::Union{Bool, Nothing} 
+    hasTimeEvents::Union{Bool, Nothing} 
 
     # c-libraries
     libHandle::Ptr{Nothing}
 
     # START: experimental section (to FMIFlux.jl)
     dependencies::Matrix
-
     # linearization jacobians
-    A::Matrix{fmi2Real}
-    B::Matrix{fmi2Real}
-    C::Matrix{fmi2Real}
-    D::Matrix{fmi2Real}
+    A::Matrix{fmi3Float64}
+    B::Matrix{fmi3Float64}
+    C::Matrix{fmi3Float64}
+    D::Matrix{fmi3Float64}
 
     # END: experimental section
 
     # Constructor
     function FMU3() 
         inst = new()
-        inst.components = []
+        inst.instances = []
+
+        inst.hasStateEvents = nothing 
+        inst.hasTimeEvents = nothing
+
+        inst.executionConfig = FMU_EXECUTION_CONFIGURATION_NO_RESET
         return inst 
     end
 end
@@ -226,7 +303,7 @@ Base.show(io::IO, fmu::FMU3) = print(io,
 Instance name:     $(fmu.instanceName)
 Model description: $(fmu.modelDescription)
 Type:              $(fmu.type)
-Components:        $(fmu.components)"
+Instances:        $(fmu.instances)"
 )
 
 """
@@ -268,3 +345,203 @@ function fmi3StatusToString(status::Integer)
 end
 
 # ToDo: Equivalent of fmi2CausalityToString, fmi2StringToCausality, ...
+
+function fmi3CausalityToString(c::fmi3Causality)
+    if c == fmi3CausalityParameter
+        return "parameter"
+    elseif c == fmi3CausalityCalculatedParameter
+        return "calculatedParameter"
+    elseif c == fmi3CausalityInput
+        return "input"
+    elseif c == fmi3CausalityOutput
+        return "output"
+    elseif c == fmi3CausalityLocal
+        return "local"
+    elseif c == fmi3CausalityIndependent
+        return "independent"
+    elseif c == fmi3CausalityStructuralParameter
+        return "structuralParameter"
+    else 
+        @assert false "fmi3CausalityToString(...): Unknown causality."
+    end
+end
+
+function fmi3StringToCausality(s::String)
+    if s == "parameter"
+        return fmi3CausalityParameter
+    elseif s == "calculatedParameter"
+        return fmi3CausalityCalculatedParameter
+    elseif s == "input"
+        return fmi3CausalityInput
+    elseif s == "output"
+        return fmi3CausalityOutput
+    elseif s == "local"
+        return fmi3CausalityLocal
+    elseif s == "independent"
+        return fmi3CausalityIndependent
+    elseif s == "structuralParameter"
+        return fmi3CausalityStructuralParameter
+    else 
+        @assert false "fmi3StringToCausality($(s)): Unknown causality."
+    end
+end
+
+function fmi3VariabilityToString(c::fmi3Variability)
+    if c == fmi3VariabilityConstant
+        return "constant"
+    elseif c == fmi3VariabilityFixed
+        return "fixed"
+    elseif c == fmi3VariabilityTunable
+        return "tunable"
+    elseif c == fmi3VariabilityDiscrete
+        return "discrete"
+    elseif c == fmi3VariabilityContinuous
+        return "continuous"
+    else 
+        @assert false "fmi3VariabilityToString(...): Unknown variability."
+    end
+end
+
+function fmi3StringToVariability(s::String)
+    if s == "constant"
+        return fmi3VariabilityConstant
+    elseif s == "fixed"
+        return fmi3VariabilityFixed
+    elseif s == "tunable"
+        return fmi3VariabilityTunable
+    elseif s == "discrete"
+        return fmi3VariabilityDiscrete
+    elseif s == "continuous"
+        return fmi3VariabilityContinuous
+    else 
+        @assert false "fmi3StringToVariability($(s)): Unknown variability."
+    end
+end
+
+function fmi3InitialToString(c::fmi3Initial)
+    if c == fmi3InitialApprox
+        return "approx"
+    elseif c == fmi3InitialExact
+        return "exact"
+    elseif c == fmi3InitialCalculated
+        return "calculated"
+    else 
+        @assert false "fmi3InitialToString(...): Unknown initial."
+    end
+end
+
+function fmi3StringToInitial(s::String)
+    if s == "approx"
+        return fmi3InitialApprox
+    elseif s == "exact"
+        return fmi3InitialExact
+    elseif s == "calculated"
+        return fmi3InitialCalculated
+    else 
+        @assert false "fmi3StringToInitial($(s)): Unknown initial."
+    end
+end
+
+function fmi3TypeToString(c::fmi3Type)
+    if c == fmi3TypeCoSimulation
+        return "coSimulation"
+    elseif c == fmi3TypeModelExchange
+        return "modelExchange"
+    elseif c == fmi3TypeScheduledExecution
+        return "scheduledExecution"
+    else 
+        @assert false "fmi3TypeToString(...): Unknown type."
+    end
+end
+
+function fmi3StringToType(s::String)
+    if s == "coSimulation"
+        return fmi3TypeCoSimulation
+    elseif s == "modelExchange"
+        return fmi3TypeModelExchange
+    elseif s == "scheduledExecution"
+        return fmi3TypeScheduledExecution
+    else 
+        @assert false "fmi3StringToInitial($(s)): Unknown type."
+    end
+end
+
+function fmi3IntervalQualifierToString(c::fmi3IntervalQualifier)
+    if c == fmi3IntervalQualifierIntervalNotYetKnown
+        return "intervalNotYetKnown"
+    elseif c == fmi3IntervalQualifierIntervalUnchanged
+        return "intervalUnchanged"
+    elseif c == fmi3IntervalQualifierIntervalChanged
+        return "intervalChanged"
+    else 
+        @assert false "fmi3IntervalQualifierToString(...): Unknown intervalQualifier."
+    end
+end
+
+function fmi3StringToIntervalQualifier(s::String)
+    if s == "intervalNotYetKnown"
+        return fmi3IntervalQualifierIntervalNotYetKnown
+    elseif s == "intervalUnchanged"
+        return fmi3IntervalQualifierIntervalUnchanged
+    elseif s == "intervalChanged"
+        return fmi3IntervalQualifierIntervalChanged
+    else 
+        @assert false "fmi3StringToIntervalQualifier($(s)): Unknown intervalQualifier."
+    end
+end
+
+function fmi3DependencyKindToString(c::fmi3DependencyKind)
+    if c == fmi3DependencyKindIndependent
+        return "independent"
+    elseif c == fmi3DependencyKindConstant
+        return "constant"
+    elseif c == fmi3DependencyKindFixed
+        return "fixed"
+    elseif c == fmi3DependencyKindTunable
+        return "tunable"
+    elseif c == fmi3DependencyKindDiscrete
+        return "discrete"
+    elseif c == fmi3DependencyKindDependent
+        return "dependent"
+    else 
+        @assert false "fmi3DependencyKindToString(...): Unknown dependencyKind."
+    end
+end
+
+function fmi3StringToDependencyKind(s::AbstractString)
+    if s == "independent"
+        return fmi3DependencyKindIndependent
+    elseif s == "constant"
+        return fmi3DependencyKindConstant
+    elseif s == "fixed"
+        return fmi3DependencyKindFixed
+    elseif s == "tunable"
+        return fmi3DependencyKindTunable
+    elseif s == "discrete"
+        return fmi3DependencyKindDiscrete
+    elseif s == "dependent"
+        return fmi3DependencyKindDependent
+    else 
+        @assert false "fmi3StringToDependencyKind($(s)): Unknown dependencyKind."
+    end
+end
+
+function fmi3VariableNamingConventionToString(c::fmi3VariableNamingConvention)
+    if c == fmi3VariableNamingConventionFlat
+        return "flat"
+    elseif c == fmi3VariableNamingConventionStructured
+        return "structured"
+    else 
+        @assert false "fmi3VariableNamingConventionToString(...): Unknown variableNamingConvention."
+    end
+end
+
+function fmi3StringToVariableNamingConvention(s::String)
+    if s == "flat"
+        return fmi3VariableNamingConventionFlat
+    elseif s == "structured"
+        return fmi3VariableNamingConventionStructured
+    else 
+        @assert false "fmi3StringToVariableNamingConvention($(s)): Unknown variableNamingConvention."
+    end
+end

--- a/src/FMI3_c.jl
+++ b/src/FMI3_c.jl
@@ -24,8 +24,8 @@ const fmi3UInt32 = Cuint
 const fmi3Int64 = Clonglong
 const fmi3UInt64 = Culonglong
 const fmi3Boolean = Cuchar
-const fmi3Char = Cchar
-const fmi3String = Ptr{fmi2Char}
+const fmi3Char = Cuchar     # changed to Cuchar to work with pointer function
+const fmi3String = Ptr{fmi3Char}
 const fmi3Byte = Cuchar
 const fmi3Binary = Ptr{fmi3Byte}
 const fmi3ValueReference = Cuint
@@ -37,6 +37,13 @@ const fmi3Clock = Cint
 
 const fmi3False = fmi3Boolean(false)
 const fmi3True = fmi3Boolean(true)
+
+"""
+A not further specified annotation struct.
+"""
+mutable struct fmi3Annotation
+    # No implementation
+end
 
 """
 Source: FMISpec3.0, Version D5ef1c1: 2.2.3. Status Returned by Functions
@@ -215,6 +222,36 @@ const fmi3DependencyKindTunable     = Cuint(3)
 const fmi3DependencyKindDiscrete    = Cuint(4)
 const fmi3DependencyKindDependent   = Cuint(5)
 
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.4.7.5.1. Variable Naming Conventions
+"""
+const fmi3VariableNamingConvention              = Cuint
+const fmi3VariableNamingConventionFlat          = Cuint(0)
+const fmi3VariableNamingConventionStructured    = Cuint(1)
+
+
+""" 
+ToDo 
+"""
+mutable struct fmi3VariableDependency
+    # mandatory 
+    reference::fmi3ValueReference
+
+    # optional
+    dependencies::Union{Array{fmi3ValueReference, 1}, Nothing}
+    dependenciesKind::Union{Array{fmi3DependencyKind, 1}, Nothing}
+
+    # Constructor 
+    function fmi3VariableDependency(reference)
+        inst = new()
+        inst.reference = reference
+        inst.dependencies = nothing
+        inst.dependenciesKind = nothing
+        return inst
+    end
+end
+
 """
 Source: FMISpec3.0, Version D5ef1c1: 2.4.7. Definition of Model Variables
                                      2.4.4. Definition of Types
@@ -266,6 +303,104 @@ mutable struct fmi3DatatypeVariable
     fmi3DatatypeVariable() = new()
 end
 
+# Custom helper, not part of the FMI-Spec. 
+mutable struct fmi3ModelDescriptionFloat 
+    # optional
+    declaredType::Union{String, Nothing}
+    quantity::Union{String, Nothing}
+    unit::Union{String, Nothing}
+    displayUnit::Union{String, Nothing}
+    relativeQuantity::Union{Bool, Nothing}
+    min::Union{Real, Nothing}
+    max::Union{Real, Nothing}
+    nominal::Union{Real, Nothing}
+    unbounded::Union{Bool, Nothing}
+    start::Union{Real, Nothing}
+    derivative::Union{UInt, Nothing}
+
+    # constructor 
+     # constructor 
+     function fmi3ModelDescriptionFloat() 
+        inst = new()
+
+        inst.start = nothing
+        inst.derivative = nothing
+        inst.quantity = nothing
+        inst.unit = nothing
+        inst.displayUnit = nothing
+        inst.relativeQuantity = nothing
+        inst.min = nothing
+        inst.max = nothing
+        inst.nominal = nothing
+        inst.unbounded = nothing
+        inst.start = nothing
+        inst.derivative = nothing
+
+        return inst 
+    end
+end
+
+# Custom helper, not part of the FMI-Spec. 
+mutable struct fmi3ModelDescriptionInteger 
+     # optional
+     start::Union{fmi3Int32, Nothing}
+     declaredType::Union{String, Nothing}
+    
+    # constructor 
+    function fmi3ModelDescriptionInteger()
+        inst = new()
+        inst.start = nothing 
+        return inst 
+    end
+end
+
+# Custom helper, not part of the FMI-Spec. 
+mutable struct fmi3ModelDescriptionBoolean 
+    # optional
+    start::Union{fmi3Boolean, Nothing}
+    declaredType::Union{String, Nothing}
+    # ToDo: remaining attributes
+    
+    # constructor 
+    function fmi3ModelDescriptionBoolean()
+        inst = new()
+        inst.start = nothing 
+        return inst 
+    end
+end
+
+# Custom helper, not part of the FMI-Spec. 
+mutable struct fmi3ModelDescriptionString
+     # optional
+     start::Union{String, Nothing}
+     declaredType::Union{String, Nothing}
+     # ToDo: remaining attributes
+     
+     # constructor 
+     function fmi3ModelDescriptionString()
+         inst = new()
+         inst.start = nothing 
+         return inst 
+     end
+end
+
+# Custom helper, not part of the FMI-Spec. 
+mutable struct fmi3ModelDescriptionEnumeration
+    # mandatory 
+    declaredType::Union{String, Nothing}
+
+    # optional
+    start::Union{fmi3Enum, Nothing}
+    # ToDo: remaining attributes
+    
+    # constructor 
+    function fmi3ModelDescriptionEnumeration() 
+        inst = new()
+        inst.start = nothing 
+        return inst 
+    end
+end
+
 """
 Source: FMISpec3.0, Version D5ef1c1: 2.4.7. Definition of Model Variables
                                      
@@ -278,50 +413,310 @@ mutable struct fmi3ModelVariable
     datatype::fmi3DatatypeVariable
 
     # Optional
-    description::String
+    description::Union{String, Nothing}
 
-    causality::fmi3Causality
-    variability::fmi3Variability
-    # initial::fmi3Initial ist in fmi3 optional
+    causality::Union{fmi3Causality, Nothing}
+    variability::Union{fmi3Variability, Nothing}
+    initial::Union{fmi3Initial, Nothing}
+    canHandleMultipleSetPerTimeInstant::Union{fmi3Boolean, Nothing}
+    annotations::Union{fmi3Annotation, Nothing}
+    clocks::Union{Array{fmi3ValueReference}, Nothing}
 
     # dependencies 
     dependencies #::Array{fmi3Int32}
     dependenciesKind #::Array{fmi3String}
 
-    # Constructor for not further specified Model variable
+    _Float::Union{fmi3ModelDescriptionFloat, Nothing}
+    _Integer::Union{fmi3ModelDescriptionInteger, Nothing}
+    _Boolean::Union{fmi3ModelDescriptionBoolean, Nothing}
+    _String::Union{fmi3ModelDescriptionString, Nothing}
+    _Enumeration::Union{fmi3ModelDescriptionEnumeration, Nothing}
+
+    # Constructor for not further specified ModelVariable
     function fmi3ModelVariable(name::String, valueReference::fmi3ValueReference)
-        new(name, valueReference, fmi3DatatypeVariable(), "", fmi3CausalityLocal::fmi3Causality, fmi3VariabilityContinuous::fmi3Variability)
+        inst = new()
+        inst.name = name 
+        inst.valueReference = valueReference
+        inst.datatype = fmi3DatatypeVariable()
+        inst.description = ""
+        inst.causality = fmi3CausalityLocal
+        inst.variability = fmi3VariabilityContinuous
+        inst.initial = fmi3InitialCalculated
+        inst.canHandleMultipleSetPerTimeInstant = fmi3False
+        inst.clocks = nothing
+        inst.annotations = nothing
+
+        inst._Float = nothing 
+        inst._Integer = nothing
+        inst._Boolean = nothing
+        inst._String = nothing 
+        inst._Enumeration = nothing
+
+        return inst
+    end
+    # Constructor for not further specified Model variable
+    # function fmi3ModelVariable(name::String, valueReference::fmi3ValueReference)
+    #     new(name, valueReference, fmi3DatatypeVariable(), "", fmi3CausalityLocal::fmi3Causality, fmi3VariabilityContinuous::fmi3Variability)
+    # end
+
+    # # Constructor for fully specified Model Variable
+    # function fmi3ModelVariable(name::String, valueReference::fmi3ValueReference, type, description, causalityString, variabilityString, dependencies, dependenciesKind)
+    #     var = fmi3VariabilityDiscrete::fmi3Variability
+    #     if type.datatype == fmi3Float32 || type.datatype == fmi3Float64
+    #         var = fmi3VariabilityContinuous::fmi3Variability
+    #     end
+    #     cau = fmi3CausalityLocal::fmi3Causality
+        
+    #     # if !occursin("fmi3" * variabilityString, string(instances(fmi3Variability)))
+    #     #     display("Error: variability not known")
+    #     # else
+    #     #     for i in 0:(length(instances(fmi3Variability))-1)
+    #     #         if "fmi3" * variabilityString == string(fmi3Variability(i))
+    #     #             var = fmi3Variability(i)
+    #     #         end
+    #     #     end
+    #     # end
+
+    #     # if !occursin("fmi3" * causalityString, string(instances(fmi3Causality)))
+    #     #     display("Error: causalitiy not known")
+    #     # else
+    #     #     for i in 0:(length(instances(fmi3Causality))-1)
+    #     #         if "fmi3" * causalityString == string(fmi3Causality(i))
+    #     #             cau = fmi3Causality(i)
+    #     #         end
+    #     #     end
+    #     # end
+
+    #     new(name, valueReference, type, description, cau, var, dependencies, dependenciesKind)
+    # end
+end
+
+""" 
+ToDo 
+"""
+mutable struct fmi3Unit
+    # ToDo 
+end
+
+""" 
+ToDo 
+"""
+mutable struct fmi3SimpleType
+    # ToDo 
+end
+
+
+# Custom helper, not part of the FMI-Spec. 
+mutable struct fmi3ModelDescriptionDefaultExperiment
+    startTime::Union{Real,Nothing}
+    stopTime::Union{Real,Nothing}
+    tolerance::Union{Real,Nothing}
+    stepSize::Union{Real,Nothing}
+
+    # Constructor 
+    function fmi3ModelDescriptionDefaultExperiment()
+        inst = new()
+        inst.startTime = nothing
+        inst.stopTime = nothing
+        inst.tolerance = nothing
+        inst.stepSize = nothing
+        return inst
+    end
+end
+
+# Custom helper, not part of the FMI-Spec. 
+mutable struct fmi3ModelDescriptionLogCategories
+    name::String
+    description::Union{String,Nothing}
+
+    # Constructor 
+    function fmi3ModelDescriptionLogCategories(name::String)
+        inst = new()
+        inst.name = name
+        inst.description = nothing
+        return inst
+    end
+end
+
+# Custom helper, not part of the FMI-Spec. 
+mutable struct fmi3ModelDescriptionClockType
+    name::String
+    description::Union{String,Nothing}
+    canBeDeactivated::Union{Bool, Nothing}
+    priority::Union{UInt, Nothing}
+    intervalVariability # TODO type
+    intervalDecimal::Union{Real, Nothing}
+    shiftDecimal::Union{Real, Nothing}
+    supportsFraction::Union{Bool, Nothing}
+    resolution::Union{UInt64, Nothing}
+    intervalCounter::Union{UInt64, Nothing}
+    shiftCounter::Union{UInt64, Nothing}
+
+    # Constructor 
+    function fmi3ModelDescriptionClockType(name::String)
+        inst = new()
+        inst.name = name
+        inst.description = nothing
+        inst.canBeDeactivated = nothing
+        inst.priority = nothing
+        inst.intervallDecimal = nothing
+        inst.shiftDecimal = nothing
+        inst.supportsFraction = nothing
+        inst.resolution = nothing
+        inst.intervalCounter = nothing
+        inst.shiftCounter = nothing
+        return inst
+    end
+end
+
+# Custom helper, not part of the FMI-Spec. 
+fmi3Unknown = fmi3VariableDependency
+
+# Custom helper, not part of the FMI-Spec. 
+mutable struct fmi3ModelDescriptionModelStructure
+    outputs::Union{Array{fmi3VariableDependency, 1}, Nothing}
+    continuousStateDerivatives::Union{Array{fmi3VariableDependency, 1}, Nothing}
+    clockedStates::Union{Array{fmi3VariableDependency, 1}, Nothing}
+    initialUnknowns::Union{Array{fmi3Unknown, 1}, Nothing}
+    eventIndicators::Union{Array{fmi3VariableDependency, 1}, Nothing}
+
+    # Constructor 
+    function fmi3ModelDescriptionModelStructure()
+        inst = new()
+        inst.outputs = nothing
+        inst.continuousStateDerivatives = nothing
+        inst.clockedStates = nothing
+        inst.initialUnknowns = nothing
+        inst.eventIndicators = nothing
+        return inst
+    end
+end
+
+# Custom helper, not part of the FMI-Spec.
+mutable struct fmi3ModelDescriptionModelExchange
+    # mandatory
+    modelIdentifier::String
+
+    # optional
+    needsExecutionTool::Union{Bool, Nothing}
+    canBeInstantiatedOnlyOncePerProcess::Union{Bool, Nothing}
+    canGetAndSetFMUstate::Union{Bool, Nothing}
+    canSerializeFMUstate::Union{Bool, Nothing}
+    providesDirectionalDerivatives::Union{Bool, Nothing}
+    providesAdjointDerivatives::Union{Bool, Nothing}
+    providesPerElementDependencies::Union{Bool, Nothing}
+    needsCompletedIntegratorStep::Union{Bool, Nothing}
+    providesEvaluateDiscreteStates::Union{Bool, Nothing}
+
+    # constructor 
+    function fmi3ModelDescriptionModelExchange() 
+        inst = new()
+        return inst 
     end
 
-    # Constructor for fully specified Model Variable
-    function fmi3ModelVariable(name::String, valueReference::fmi3ValueReference, type, description, causalityString, variabilityString, dependencies, dependenciesKind)
-        var = fmi3VariabilityDiscrete::fmi3Variability
-        if type.datatype == fmi3Float32 || type.datatype == fmi3Float64
-            var = fmi3VariabilityContinuous::fmi3Variability
-        end
-        cau = fmi3CausalityLocal::fmi3Causality
-        
-        # if !occursin("fmi3" * variabilityString, string(instances(fmi3Variability)))
-        #     display("Error: variability not known")
-        # else
-        #     for i in 0:(length(instances(fmi3Variability))-1)
-        #         if "fmi3" * variabilityString == string(fmi3Variability(i))
-        #             var = fmi3Variability(i)
-        #         end
-        #     end
-        # end
+    function fmi3ModelDescriptionModelExchange(modelIdentifier::String) 
+        inst = fmi3ModelDescriptionModelExchange() 
+        inst.modelIdentifier = modelIdentifier
+        inst.needsExecutionTool = nothing
+        inst.canBeInstantiatedOnlyOncePerProcess = nothing
+        inst.canGetAndSetFMUstate = nothing
+        inst.canSerializeFMUstate = nothing
+        inst.providesDirectionalDerivatives = nothing
+        inst.providesAdjointDerivatives = nothing
+        inst.providesPerElementDependencies = nothing
+        inst.needsCompletedIntegratorStep = nothing
+        inst.providesEvaluateDiscreteStates = nothing
+        return inst 
+    end
+end
 
-        # if !occursin("fmi3" * causalityString, string(instances(fmi3Causality)))
-        #     display("Error: causalitiy not known")
-        # else
-        #     for i in 0:(length(instances(fmi3Causality))-1)
-        #         if "fmi3" * causalityString == string(fmi3Causality(i))
-        #             cau = fmi3Causality(i)
-        #         end
-        #     end
-        # end
+# Custom helper, not part of the FMI-Spec.
+mutable struct fmi3ModelDescriptionCoSimulation
+    # mandatory
+    modelIdentifier::String
 
-        new(name, valueReference, type, description, cau, var, dependencies, dependenciesKind)
+    # optional
+    needsExecutionTool::Union{Bool, Nothing}
+    canBeInstantiatedOnlyOncePerProcess::Union{Bool, Nothing}
+    canGetAndSetFMUstate::Union{Bool, Nothing}
+    canSerializeFMUstate::Union{Bool, Nothing}
+    providesDirectionalDerivatives::Union{Bool, Nothing}
+    providesAdjointDerivatives::Union{Bool, Nothing}
+    providesPerElementDependencies::Union{Bool, Nothing}
+    needsCompletedIntegratorStep::Union{Bool, Nothing}
+    providesEvaluateDiscreteStates::Union{Bool, Nothing}
+    canHandleVariableCommunicationStepSize::Union{Bool, Nothing}
+    fixedInternalStepSize::Union{Real, Nothing}
+    recommendedIntermediateInputSmoothness::Union{Int, Nothing}
+    maxOutputDerivativeOrder::Union{UInt, Nothing}
+    providesIntermediateUpdate::Union{Bool, Nothing}
+    mightReturnEarlyFromDoStep::Union{Bool, Nothing}
+    canReturnEarlyAfterIntermediateUpdate::Union{Bool, Nothing}
+    hasEventMode::Union{Bool, Nothing}
+    canInterpolateInputs::Union{Bool, Nothing}
+
+    # constructor 
+    function fmi3ModelDescriptionCoSimulation() 
+        inst = new()
+        return inst 
+    end
+
+    function fmi3ModelDescriptionCoSimulation(modelIdentifier::String) 
+        inst = fmi3ModelDescriptionCoSimulation()
+        inst.modelIdentifier = modelIdentifier
+        inst.needsExecutionTool = nothing
+        inst.canBeInstantiatedOnlyOncePerProcess = nothing
+        inst.canGetAndSetFMUstate = nothing
+        inst.canSerializeFMUstate = nothing
+        inst.providesDirectionalDerivatives = nothing
+        inst.providesAdjointDerivatives = nothing
+        inst.providesPerElementDependencies = nothing
+        inst.needsCompletedIntegratorStep = nothing
+        inst.providesEvaluateDiscreteStates = nothing
+        inst.needsCompletedIntegratorStep = nothing
+        inst.canHandleVariableCommunicationStepSize = nothing
+        inst.fixedInternalStepSize = nothing
+        inst.recommendedIntermediateInputSmoothness = nothing
+        inst.maxOutputDerivativeOrder = nothing
+        inst.providesIntermediateUpdate = nothing
+        inst.mightReturnEarlyFromDoStep = nothing
+        inst.canReturnEarlyAfterIntermediateUpdate = nothing
+        inst.hasEventMode = nothing
+        return inst 
+    end
+end
+
+# Custom helper, not part of the FMI-Spec.
+mutable struct fmi3ModelDescriptionScheduledExecution
+    # mandatory
+    modelIdentifier::String
+
+    # optional
+    needsExecutionTool::Union{Bool, Nothing}
+    canBeInstantiatedOnlyOncePerProcess::Union{Bool, Nothing}
+    canGetAndSetFMUstate::Union{Bool, Nothing}
+    canSerializeFMUstate::Union{Bool, Nothing}
+    providesDirectionalDerivatives::Union{Bool, Nothing}
+    providesAdjointDerivatives::Union{Bool, Nothing}
+    providesPerElementDependencies::Union{Bool, Nothing}
+
+    # constructor 
+    function fmi3ModelDescriptionScheduledExecution() 
+        inst = new()
+        return inst 
+    end
+
+    function fmi3ModelDescriptionScheduledExecution(modelIdentifier::String) 
+        inst = fmi3ModelDescriptionScheduledExecution() 
+        inst.modelIdentifier = modelIdentifier
+        inst.needsExecutionTool = nothing
+        inst.canBeInstantiatedOnlyOncePerProcess = nothing
+        inst.canGetAndSetFMUstate = nothing
+        inst.canSerializeFMUstate = nothing
+        inst.providesDirectionalDerivatives = nothing
+        inst.providesAdjointDerivatives = nothing
+        inst.providesPerElementDependencies = nothing
+        return inst 
     end
 end
 
@@ -334,79 +729,1238 @@ mutable struct fmi3ModelDescription
     # FMI model description
     fmiVersion::String
     modelName::String
-    generationTool::String
-    generationDateAndTime::String
-    variableNamingConvention::String
     instantiationToken::String  # replaces GUID
 
-    CSmodelIdentifier::String
-    CSneedsExecutionTool::Bool
-    CScanBeInstantiatedOnlyOncePerProcess::Bool
-    CScanGetAndSetFMUstate::Bool
-    CScanSerializeFMUstate::Bool
-    CSprovidesDirectionalDerivatives::Bool
-    CSproivdesAdjointDerivatives::Bool
-    CSprovidesPerElementDependencies::Bool
-    CScanHandleVariableCommunicationStepSize::Bool
-    CSmaxOutputDerivativeOrder::UInt
-    CSprovidesIntermediateUpdate::Bool
-    CSrecommendedIntermediateInputSmoothness::Int
-    CScanReturnEarlyAfterIntermediateUpdate::Bool
-    CShasEventMode::Bool
-    CSprovidesEvaluateDiscreteStates::Bool
+    # optional
+    description::Union{String, Nothing}
+    author::Union{String, Nothing}
+    version::Union{String, Nothing}
+    copyright::Union{String, Nothing}
+    license::Union{String, Nothing}
+    generationTool::Union{String, Nothing}
+    generationDateAndTime # DateTime
+    variableNamingConvention::Union{fmi3VariableNamingConvention, Nothing}
 
-    MEmodelIdentifier::String
-    MEneedsExecutionTool::Bool
-    MEcanBeInstantiatedOnlyOncePerProcess::Bool
-    MEcanGetAndSetFMUstate::Bool
-    MEcanSerializeFMUstate::Bool
-    MEprovidesDirectionalDerivatives::Bool
-    MEprovidesAdjointDerivatives::Bool
-    MEprovidesPerElementDependencies::Bool
+    unitDefinitions::Array{fmi3Unit, 1} 
+    typeDefinitions::Array{fmi3SimpleType, 1} 
+    logCategories::Array # ToDo: Array type
 
-    SEmodelIdentifier::String
-    SEneedsExecutionTool::Bool
-    SEcanBeInstantiatedOnlyOncePerProcess::Bool
-    SEcanGetAndSetFMUstate::Bool
-    SEcanSerializeFMUstate::Bool
-    SEprovidesDirectionalDerivatives::Bool
-    SEprovidesAdjointDerivatives::Bool
-    SEprovidesPerElementDependencies::Bool
+    defaultExperiment::Union{fmi3ModelDescriptionDefaultExperiment, Nothing}
+    clockType::Union{fmi3ModelDescriptionClockType, Nothing}
 
-    # helpers
-    isCoSimulation::Bool
-    isModelExchange::Bool
-    isScheduledExecution::Bool
+    vendorAnnotations::Array # ToDo: Array type
+    modelVariables::Array{fmi3ModelVariable, 1} 
+    modelStructure::fmi3ModelDescriptionModelStructure
 
-    description::String
-
-    # Model variables
-    modelVariables::Array{fmi3ModelVariable,1}
+    modelExchange::Union{fmi3ModelDescriptionModelExchange, Nothing}
+    coSimulation::Union{fmi3ModelDescriptionCoSimulation, Nothing}
+    scheduledExecution::Union{fmi3ModelDescriptionScheduledExecution, Nothing}
 
     # additionals
     valueReferences::Array{fmi3ValueReference}
-
     inputValueReferences::Array{fmi3ValueReference}
     outputValueReferences::Array{fmi3ValueReference}
     stateValueReferences::Array{fmi3ValueReference}
     derivativeValueReferences::Array{fmi3ValueReference}
     intermediateUpdateValueReferences::Array{fmi3ValueReference}
-
+    parameterValueReferences::Array{fmi3ValueReference}
+    stringValueReferences::Dict{String, fmi3ValueReference}
+ 
     numberOfContinuousStates::Int
-    numberOfEventIndicators::Int
+    numberOfEventIndicators::Union{UInt, Nothing}
     enumerations::fmi3Enum
-
-    stringValueReferences
 
     defaultStartTime::fmi3Float64
     defaultStopTime::fmi3Float64
     defaultTolerance::fmi3Float64
 
-    # Constructor for uninitialized struct
-    fmi3ModelDescription() = new()
-
     # additional fields (non-FMI-specific)
     valueReferenceIndicies::Dict{Integer,Integer}
+
+    # Constructor for uninitialized struct
+    function fmi3ModelDescription()
+        inst = new()
+        inst.fmiVersion = ""
+        inst.modelName = ""
+        inst.instantiationToken = ""
+
+        inst.modelExchange = nothing 
+        inst.coSimulation = nothing
+        inst.scheduledExecution = nothing
+        inst.defaultExperiment = nothing
+        inst.clockType = nothing
+
+        inst.modelVariables = Array{fmi3ModelVariable, 1}()
+        inst.modelStructure = fmi3ModelDescriptionModelStructure()
+        inst.numberOfEventIndicators = nothing
+        inst.enumerations = []
+
+        inst.valueReferences = []
+        inst.inputValueReferences = []
+        inst.outputValueReferences = []
+        inst.stateValueReferences = []
+        inst.derivativeValueReferences = []
+        inst.parameterValueReferences = []
+
+        return inst 
+    end
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1:: 2.3.1. Super State: FMU State Setable
+
+This function instantiates a Model Exchange FMU (see Section 3). It is allowed to call this function only if modelDescription.xml includes a <ModelExchange> element.
+"""
+function fmi3InstantiateModelExchange(cfunc::Ptr{Nothing},
+        instanceName::fmi3String,
+        fmuinstantiationToken::fmi3String,
+        fmuResourceLocation::fmi3String,
+        visible::fmi3Boolean,
+        loggingOn::fmi3Boolean,
+        instanceEnvironment::fmi3InstanceEnvironment,
+        logMessage::Ptr{Cvoid})
+
+    compAddr = ccall(cfunc,
+        Ptr{Cvoid},
+        (Cstring, Cstring, Cstring,
+        Cuint, Cuint, Ptr{Cvoid}, Ptr{Cvoid}),
+        instanceName, fmuinstantiationToken, fmuResourceLocation,
+        visible, loggingOn, instanceEnvironment, logMessage)
+
+    compAddr
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1:: 2.3.1. Super State: FMU State Setable
+
+This function instantiates a Co-Simulation FMU (see Section 4). It is allowed to call this function only if modelDescription.xml includes a <CoSimulation> element.
+"""
+function fmi3InstantiateCoSimulation(cfunc::Ptr{Nothing},
+    instanceName::fmi3String,
+    instantiationToken::fmi3String,
+    resourcePath::fmi3String,
+    visible::fmi3Boolean,
+    loggingOn::fmi3Boolean,
+    eventModeUsed::fmi3Boolean,
+    earlyReturnAllowed::fmi3Boolean,
+    requiredIntermediateVariables::Array{fmi3ValueReference},
+    nRequiredIntermediateVariables::Csize_t,
+    instanceEnvironment::fmi3InstanceEnvironment,
+    logMessage::Ptr{Cvoid},
+    intermediateUpdate::Ptr{Cvoid})
+
+    compAddr = ccall(cfunc,
+        Ptr{Cvoid},
+        (Cstring, Cstring, Cstring,
+        Cint, Cint, Cint, Cint, Ptr{fmi3ValueReference}, Csize_t, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        instanceName, instantiationToken, resourcePath,
+        visible, loggingOn, eventModeUsed, earlyReturnAllowed, requiredIntermediateVariables,
+        nRequiredIntermediateVariables, instanceEnvironment, logMessage, intermediateUpdate)
+
+    compAddr
+end
+
+# TODO not tested
+"""
+Source: FMISpec3.0, Version D5ef1c1:: 2.3.1. Super State: FMU State Setable
+
+This function instantiates a Scheduled Execution FMU (see Section 4). It is allowed to call this function only if modelDescription.xml includes a <ScheduledExecution> element.
+"""
+function fmi3InstantiateScheduledExecution(cfunc::Ptr{Nothing},
+    instanceName::fmi3String,
+    instantiationToken::fmi3String,
+    resourcePath::fmi3String,
+    visible::fmi3Boolean,
+    loggingOn::fmi3Boolean,
+    instanceEnvironment::fmi3InstanceEnvironment,
+    logMessage::Ptr{Cvoid},
+    clockUpdate::Ptr{Cvoid},
+    lockPreemption::Ptr{Cvoid},
+    unlockPreemption::Ptr{Cvoid})
+    @assert false "Not tested!"
+    compAddr = ccall(cfunc,
+        Ptr{Cvoid},
+        (Cstring, Cstring, Cstring,
+        Cint, Cint, Cint, Cint, Ptr{fmi3ValueReference}, Csize_t, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        instanceName, instantiationToken, resourcePath,
+        visible, loggingOn, eventModeUsed, earlyReturnAllowed, requiredIntermediateVariables,
+        nRequiredIntermediateVariables, instanceEnvironment, logMessage, clockUpdate, lockPreemption, unlockPreemption)
+
+    compAddr
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.4. Inquire Version Number of Header Files
+
+This function returns fmi3Version of the fmi3Functions.h header file which was used to compile the functions of the FMU. This function call is allowed always and in all interface types.
+
+The standard header file as documented in this specification has version "3.0-beta.2", so this function returns "3.0-beta.2".
+"""
+function fmi3GetVersion(cfunc::Ptr{Nothing})
+    ccall(cfunc, fmi3String, ())
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.1. Super State: FMU State Setable
+
+Disposes the given instance, unloads the loaded model, and frees all the allocated memory and other resources that have been allocated by the functions of the FMU interface. If a NULL pointer is provided for argument instance, the function call is ignored (does not have an effect).
+"""
+function fmi3FreeInstance!(cfunc::Ptr{Nothing}, c::fmi2Component)
+
+    ccall(cfunc, Cvoid, (Ptr{Cvoid},), c)
+
+    nothing
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.1. Super State: FMU State Setable
+
+The function controls debug logging that is output via the logger function callback. If loggingOn = fmi3True, debug logging is enabled, otherwise it is switched off.
+"""
+function fmi3SetDebugLogging(cfunc::Ptr{Nothing}, c::fmi3Instance, logginOn::fmi3Boolean, nCategories::UInt, categories::Ptr{Nothing})
+    status = ccall(cfunc,
+                   fmi3Status,
+                   (fmi3Instance, Cint, Csize_t, Ptr{Nothing}),
+                   c, logginOn, nCategories, categories)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.2. State: Instantiated
+
+Informs the FMU to enter Initialization Mode. Before calling this function, all variables with attribute <Datatype initial = "exact" or "approx"> can be set with the “fmi3SetXXX” functions (the ScalarVariable attributes are defined in the Model Description File, see section 2.4.7). Setting other variables is not allowed.
+Also sets the simulation start and stop time.
+"""
+function fmi3EnterInitializationMode(cfunc::Ptr{Nothing}, c::fmi3Instance, toleranceDefined::fmi3Boolean,
+    tolerance::fmi3Float64,
+    startTime::fmi3Float64,
+    stopTimeDefined::fmi3Boolean,
+    stopTime::fmi3Float64)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, fmi3Boolean, fmi3Float64, fmi3Float64, fmi3Boolean, fmi3Float64),
+          c, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.3. State: Initialization Mode
+
+Informs the FMU to exit Initialization Mode.
+"""
+function fmi3ExitInitializationMode(cfunc::Ptr{Nothing}, c::fmi3Instance)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance,),
+          c)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.4. Super State: Initialized
+
+Informs the FMU that the simulation run is terminated.
+"""
+function fmi3Terminate(cfunc::Ptr{Nothing}, c::fmi3Instance)
+    ccall(cfunc, fmi3Status, (fmi3Instance,), c)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.1. Super State: FMU State Setable
+
+Is called by the environment to reset the FMU after a simulation run. The FMU goes into the same state as if fmi3InstantiateXXX would have been called.
+"""
+function fmi3Reset(cfunc::Ptr{Nothing}, c::fmi3Instance)
+    ccall(cfunc, fmi3Status, (fmi3Instance,), c)
+end
+
+# TODO test, no variable in FMUs
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetFloat32!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Float32}, nvalue::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Float32}, Csize_t),
+          c, vr, nvr, value, nvalue)
+end
+
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetFloat32(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Float32}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Float32}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetFloat64!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Float64}, nvalue::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Float64}, Csize_t),
+          c, vr, nvr, value, nvalue)
+end
+
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetFloat64(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Float64}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Float64}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+# TODO test, no variable in FMUs
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetInt8!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Int8}, nvalue::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Int8}, Csize_t),
+          c, vr, nvr, value, nvalue)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetInt8(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Int8}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Int8}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+# TODO test, no variable in FMUs
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetUInt8!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3UInt8}, nvalue::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt8}, Csize_t),
+          c, vr, nvr, value, nvalue)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetUInt8(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3UInt8}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt8}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+# TODO test, no variable in FMUs
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetInt16!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Int16}, nvalue::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Int16}, Csize_t),
+          c, vr, nvr, value, nvalue)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetInt16(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Int16}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Int16}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+# TODO test, no variable in FMUs
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetUInt16!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3UInt16}, nvalue::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt16}, Csize_t),
+          c, vr, nvr, value, nvalue)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetUInt16(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3UInt16}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt16}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetInt32!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Int32}, nvalue::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Int32}, Csize_t),
+          c, vr, nvr, value, nvalue)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetInt32(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Int32}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Int32}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+# TODO test, no variable in FMUs
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetUInt32!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3UInt32}, nvalue::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt32}, Csize_t),
+          c, vr, nvr, value, nvalue)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetUInt32(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3UInt32}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt32}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+# TODO test, no variable in FMUs
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetInt64!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Int64}, nvalue::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Int64}, Csize_t),
+          c, vr, nvr, value, nvalue)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetInt64(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Int64}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Int64}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+# TODO test, no variable in FMUs
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetUInt64!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3UInt64}, nvalue::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt64}, Csize_t),
+          c, vr, nvr, value, nvalue)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetUInt64(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3UInt64}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt64}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetBoolean!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Boolean}, nvalue::Csize_t)
+    status = ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Boolean}, Csize_t),
+          c, vr, nvr, value, nvalue)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetBoolean(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Boolean}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Boolean}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+# TODO change to fmi3String when possible to test
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetString!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Vector{Ptr{Cchar}}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t,  Ptr{Cchar}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""     
+function fmi3SetString(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Union{Array{Ptr{Cchar}}, Array{Ptr{UInt8}}}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{Cchar}, Csize_t),
+                c, vr, nvr, value, nvalue)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValues - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetBinary!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, valueSizes::Array{Csize_t}, value::Array{fmi3Binary}, nvalue::Csize_t)
+    ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{Csize_t}, Ptr{fmi3Binary}, Csize_t),
+                c, vr, nvr, valueSizes, value, nvalue)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetBinary(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, valueSizes::Array{Csize_t}, value::Array{fmi3Binary}, nvalue::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{Csize_t}, Ptr{fmi3Binary}, Csize_t),
+                c, vr, nvr, valueSizes, value, nvalue)
+    status
+end
+
+# TODO, Clocks not implemented so far thus not tested
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3GetClock!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Clock})
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t,  Ptr{fmi3Clock}),
+                c, vr, nvr, value)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.2. Getting and Setting Variable Values
+
+Functions to get and set values of variables idetified by their valueReference.
+
+nValue - is different from nvr if the value reference represents an array and therefore are more values tied to a single value reference.
+"""
+function fmi3SetClock(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, value::Array{fmi3Clock})
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance,Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Clock}),
+                c, vr, nvr, value)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.4. Getting and Setting the Complete FMU State
+
+fmi3GetFMUstate makes a copy of the internal FMU state and returns a pointer to this copy
+"""
+function fmi3GetFMUState!(cfunc::Ptr{Nothing}, c::fmi3Instance, FMUstate::Ref{fmi3FMUState})
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3FMUState}),
+                c, FMUstate)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.4. Getting and Setting the Complete FMU State
+
+fmi3SetFMUstate copies the content of the previously copied FMUstate back and uses it as actual new FMU state.
+"""
+function fmi3SetFMUState(cfunc::Ptr{Nothing}, c::fmi3Instance, FMUstate::fmi3FMUState)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, fmi3FMUState),
+                c, FMUstate)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.4. Getting and Setting the Complete FMU State
+
+fmi3FreeFMUstate frees all memory and other resources allocated with the fmi3GetFMUstate call for this FMUstate.
+"""
+function fmi3FreeFMUState!(cfunc::Ptr{Nothing}, c::fmi3Instance, FMUstate::Ref{fmi3FMUState})
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3FMUState}),
+                c, FMUstate)
+    status
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.4. Getting and Setting the Complete FMU State
+
+fmi3SerializedFMUstateSize returns the size of the byte vector which is needed to store FMUstate in it.
+"""
+function fmi3SerializedFMUStateSize!(cfunc::Ptr{Nothing}, c::fmi3Instance, FMUstate::fmi3FMUState, size::Ref{Csize_t})
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{Cvoid}, Ptr{Csize_t}),
+                c, FMUstate, size)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.4. Getting and Setting the Complete FMU State
+
+fmi3SerializeFMUstate serializes the data which is referenced by pointer FMUstate and copies this data in to the byte vector serializedState of length size
+"""
+function fmi3SerializeFMUState!(cfunc::Ptr{Nothing}, c::fmi3Instance, FMUstate::fmi3FMUState, serialzedState::Array{fmi3Byte}, size::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{Cvoid}, Ptr{Cchar}, Csize_t),
+                c, FMUstate, serialzedState, size)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.6.4. Getting and Setting the Complete FMU State
+
+fmi3DeSerializeFMUstate deserializes the byte vector serializedState of length size, constructs a copy of the FMU state and returns FMUstate, the pointer to this copy.
+"""
+function fmi3DeSerializeFMUState!(cfunc::Ptr{Nothing}, c::fmi3Instance, serialzedState::Array{fmi3Byte}, size::Csize_t, FMUstate::Ref{fmi3FMUState})
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{Cchar}, Csize_t, Ptr{fmi3FMUState}),
+                c, serialzedState, size, FMUstate)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.9. Clocks
+
+fmi3SetIntervalDecimal sets the interval until the next clock tick
+"""
+# TODO Clocks and dependencies functions
+function fmi3SetIntervalDecimal(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, intervals::Array{fmi3Float64})
+    @assert false "Not tested"
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Float64}),
+                c, vr, nvr, intervals)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.9. Clocks
+
+fmi3SetIntervalFraction sets the interval until the next clock tick
+Only allowed if the attribute 'supportsFraction' is set.
+"""
+function fmi3SetIntervalFraction(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, intervalCounters::Array{fmi3UInt64}, resolutions::Array{fmi3UInt64})
+    @assert false "Not tested"
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt64}, Ptr{fmi3UInt64}),
+                c, vr, nvr, intervalCounters, resolutions)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.9. Clocks
+
+fmi3GetIntervalDecimal retrieves the interval until the next clock tick.
+
+For input Clocks it is allowed to call this function to query the next activation interval.
+For changing aperiodic Clock, this function must be called in every Event Mode where this clock was activated.
+For countdown aperiodic Clock, this function must be called in every Event Mode.
+Clock intervals are computed in fmi3UpdateDiscreteStates (at the latest), therefore, this function should be called after fmi3UpdateDiscreteStates.
+For information about fmi3IntervalQualifiers, call ?fmi3IntervalQualifier
+"""
+function fmi3GetIntervalDecimal!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, intervals::Array{fmi3Float64}, qualifiers::fmi3IntervalQualifier)
+    @assert false "Not tested"
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Float64}, Ptr{fmi3IntervalQualifier}),
+                c, vr, nvr, intervals, qualifiers)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.9. Clocks
+
+fmi3GetIntervalFraction retrieves the interval until the next clock tick.
+
+For input Clocks it is allowed to call this function to query the next activation interval.
+For changing aperiodic Clock, this function must be called in every Event Mode where this clock was activated.
+For countdown aperiodic Clock, this function must be called in every Event Mode.
+Clock intervals are computed in fmi3UpdateDiscreteStates (at the latest), therefore, this function should be called after fmi3UpdateDiscreteStates.
+For information about fmi3IntervalQualifiers, call ?fmi3IntervalQualifier
+"""
+function fmi3GetIntervalFraction!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, intervalCounters::Array{fmi3UInt64}, resolutions::Array{fmi3UInt64}, qualifiers::fmi3IntervalQualifier)
+    @assert false "Not tested"
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt64}, Ptr{fmi3UInt64}, Ptr{fmi3IntervalQualifier}),
+                c, vr, nvr, intervalCounters, resolutions, qualifiers)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.9. Clocks
+
+fmi3GetShiftDecimal retrieves the delay to the first Clock tick from the FMU.
+"""
+function fmi3GetShiftDecimal!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, shifts::Array{fmi3Float64})
+    @assert false "Not tested"
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Float64}),
+                c, vr, nvr, shifts)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.9. Clocks
+
+fmi3GetShiftFraction retrieves the delay to the first Clock tick from the FMU.
+"""
+function fmi3GetShiftFraction!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nvr::Csize_t, shiftCounters::Array{fmi3UInt64}, resolutions::Array{fmi3UInt64})
+    @assert false "Not tested"
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3UInt64}, Ptr{fmi3UInt64}),
+                c, vr, nvr, shiftCounters, resolutions)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 5.2.2. State: Clock Activation Mode
+
+During Clock Activation Mode (see 5.2.2.) after fmi3ActivateModelPartition has been called for a calculated, tunable or changing Clock the FMU provides the information on when the Clock will tick again, i.e. when the corresponding model partition has to be scheduled the next time.
+
+Each fmi3ActivateModelPartition call is associated with the computation of an exposed model partition of the FMU and therefore to an input Clock.
+"""
+function fmi3ActivateModelPartition(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::fmi3ValueReference, activationTime::Array{fmi3Float64})
+    @assert false "Not tested"
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, fmi3ValueReference, Ptr{fmi3Float64}),
+                c, vr, activationTime)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.10. Dependencies of Variables
+
+The number of dependencies of a given variable, which may change if structural parameters are changed, can be retrieved by calling fmi3GetNumberOfVariableDependencies.
+
+This information can only be retrieved if the 'providesPerElementDependencies' tag in the ModelDescription is set.
+"""
+# TODO not tested
+function fmi3GetNumberOfVariableDependencies!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::fmi3ValueReference, nvr::Ref{Csize_t})
+    @assert false "Not tested"
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, fmi3ValueReference, Ptr{Csize_t}),
+                c, vr, nvr)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.10. Dependencies of Variables
+
+The actual dependencies (of type dependenciesKind) can be retrieved by calling the function fmi3GetVariableDependencies:
+
+dependent - specifies the valueReference of the variable for which the dependencies should be returned.
+
+nDependencies - specifies the number of dependencies that the calling environment allocated space for in the result buffers, and should correspond to value obtained by calling fmi3GetNumberOfVariableDependencies.
+
+elementIndicesOfDependent - must point to a buffer of size_t values of size nDependencies allocated by the calling environment. 
+It is filled in by this function with the element index of the dependent variable that dependency information is provided for. The element indices start with 1. Using the element index 0 means all elements of the variable. (Note: If an array has more than one dimension the indices are serialized in the same order as defined for values in Section 2.2.6.1.)
+
+independents -  must point to a buffer of fmi3ValueReference values of size nDependencies allocated by the calling environment. 
+It is filled in by this function with the value reference of the independent variable that this dependency entry is dependent upon.
+
+elementIndicesIndependents - must point to a buffer of size_t values of size nDependencies allocated by the calling environment. 
+It is filled in by this function with the element index of the independent variable that this dependency entry is dependent upon. The element indices start with 1. Using the element index 0 means all elements of the variable. (Note: If an array has more than one dimension the indices are serialized in the same order as defined for values in Section 2.2.6.1.)
+
+dependencyKinds - must point to a buffer of dependenciesKind values of size nDependencies allocated by the calling environment. 
+It is filled in by this function with the enumeration value describing the dependency of this dependency entry.
+For more information about dependenciesKinds, call ?fmi3DependencyKind
+
+If this function is called before the fmi3ExitInitializationMode call, it returns the initial dependencies. If this function is called after the fmi3ExitInitializationMode call, it returns the runtime dependencies. 
+The retrieved dependency information of one variable becomes invalid as soon as a structural parameter linked to the variable or to any of its depending variables are set. As a consequence, if you change structural parameters affecting B or A, the dependency of B becomes invalid. The dependency information must change only if structural parameters are changed.
+
+This information can only be retrieved if the 'providesPerElementDependencies' tag in the ModelDescription is set.
+"""
+function fmi3GetVariableDependencies!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::fmi3ValueReference, elementIndiceOfDependents::Array{Csize_t}, independents::Array{fmi3ValueReference},  elementIndiceOfInpendents::Array{Csize_t}, dependencyKind::Array{fmi3DependencyKind}, ndependencies::Csize_t)
+    @assert false "Not tested"
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, fmi3ValueReference, Ptr{Csize_t}, Ptr{fmi3ValueReference}, Ptr{Csize_t}, Ptr{fmi3DependencyKind}, Csize_t),
+                c, vr, elementIndiceOfDependents, independents, elementIndiceOfInpendents, dependencyKind, ndependencies)
+end
+
+# TODO not tested
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.11. Getting Partial Derivatives
+
+This function computes the directional derivatives v_{sensitivity} = J ⋅ v_{seed} of an FMU.
+
+unknowns - contains value references to the unknowns.
+
+nUnknowns - contains the length of argument unknowns.
+
+knowns - contains value references of the knowns.
+
+nKnowns - contains the length of argument knowns.
+
+seed - contains the components of the seed vector.
+
+nSeed - contains the length of seed.
+
+sensitivity - contains the components of the sensitivity vector.
+
+nSensitivity - contains the length of sensitivity.
+
+This function can only be called if the 'ProvidesDirectionalDerivatives' tag in the ModelDescription is set.
+"""
+function fmi3GetDirectionalDerivative!(cfunc::Ptr{Nothing}, c::fmi3Instance,
+                                       unknowns::Array{fmi3ValueReference},
+                                       nUnknowns::Csize_t,
+                                       knowns::Array{fmi3ValueReference},
+                                       nKnowns::Csize_t,
+                                       seed::Array{fmi3Float64},
+                                       nSeed::Csize_t,
+                                       sensitivity::Array{fmi3Float64},
+                                       nSensitivity::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Float64}, Csize_t, Ptr{fmi3Float64}, Csize_t),
+          c, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity)
+    
+end
+
+# TODO not tested
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.11. Getting Partial Derivatives
+
+This function computes the adjoint derivatives v^T_{sensitivity}= v^T_{seed} ⋅ J of an FMU.
+
+unknowns - contains value references to the unknowns.
+
+nUnknowns - contains the length of argument unknowns.
+
+knowns - contains value references of the knowns.
+
+nKnowns - contains the length of argument knowns.
+
+seed - contains the components of the seed vector.
+
+nSeed - contains the length of seed.
+
+sensitivity - contains the components of the sensitivity vector.
+
+nSensitivity - contains the length of sensitivity.
+
+This function can only be called if the 'ProvidesAdjointDerivatives' tag in the ModelDescription is set.
+"""
+function fmi3GetAdjointDerivative!(cfunc::Ptr{Nothing}, c::fmi3Instance,
+                                       unknowns::Array{fmi3ValueReference},
+                                       nUnknowns::Csize_t,
+                                       knowns::Array{fmi3ValueReference},
+                                       nKnowns::Csize_t,
+                                       seed::Array{fmi3Float64},
+                                       nSeed::Csize_t,
+                                       sensitivity::Array{fmi3Float64},
+                                       nSensitivity::Csize_t)
+    @assert fmi3ProvidesAdjointDerivatives(c.fmu) ["fmi3GetAdjointDerivative!(...): This FMU does not support build-in adjoint derivatives!"]
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Float64}, Csize_t, Ptr{fmi3Float64}, Csize_t),
+          c, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity)
+    
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.2.12. Getting Derivatives of Continuous Outputs
+
+Retrieves the n-th derivative of output values.
+
+valueReferences - is a vector of value references that define the variables whose derivatives shall be retrieved. If multiple derivatives of a variable shall be retrieved, list the value reference multiple times.
+
+nValueReferences - is the dimension of the arguments valueReferences and orders.
+
+orders - contains the orders of the respective derivative (1 means the first derivative, 2 means the second derivative, …, 0 is not allowed). 
+If multiple derivatives of a variable shall be retrieved, provide a list of them in the orders array, corresponding to a multiply occurring value reference in the valueReferences array.
+The highest order of derivatives retrievable can be determined by the 'maxOutputDerivativeOrder' tag in the ModelDescription.
+
+values - is a vector with the values of the derivatives. The order of the values elements is derived from a twofold serialization: the outer level corresponds to the combination of a value reference (e.g., valueReferences[k]) and order (e.g., orders[k]), and the inner level to the serialization of variables as defined in Section 2.2.6.1. The inner level does not exist for scalar variables.
+
+nValues - is the size of the argument values. nValues only equals nValueReferences if all corresponding output variables are scalar variables.
+"""
+function fmi3GetOutputDerivatives!(cfunc::Ptr{Nothing}, c::fmi3Instance, vr::Array{fmi3ValueReference}, nValueReferences::Csize_t, order::Array{fmi3Int32}, values::Array{fmi3Float64}, nValues::Csize_t)
+    status = ccall(cfunc,
+                fmi3Status,
+                (fmi3Instance, Ptr{fmi3ValueReference}, Csize_t, Ptr{fmi3Int32}, Ptr{fmi3Float64}, Csize_t),
+                c, vr, nValueReferences, order, values, nValues)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.2. State: Instantiated
+
+If the importer needs to change structural parameters, it must move the FMU into Configuration Mode using fmi3EnterConfigurationMode.
+"""
+function fmi3EnterConfigurationMode(cfunc::Ptr{Nothing}, c::fmi3Instance)
+    ccall(cfunc,
+            fmi3Status,
+            (fmi3Instance,),
+            c)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.6. State: Configuration Mode
+
+Exits the Configuration Mode and returns to state Instantiated.
+"""
+function fmi3ExitConfigurationMode(cfunc::Ptr{Nothing}, c::fmi3Instance)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance,),
+          c)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.2. State: Instantiated
+
+This function returns the number of continuous states.
+This function can only be called in Model Exchange. 
+
+fmi3GetNumberOfContinuousStates must be called after a structural parameter is changed. As long as no structural parameters changed, the number of states is given in the modelDescription.xml, alleviating the need to call this function.
+"""
+function fmi3GetNumberOfContinuousStates!(cfunc::Ptr{Nothing}, c::fmi3Instance, nContinuousStates::Ref{Csize_t})
+    ccall(cfunc,
+            fmi3Status,
+            (fmi3Instance, Ptr{Csize_t}),
+            c, nContinuousStates)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.2. State: Instantiated
+
+This function returns the number of event indicators.
+This function can only be called in Model Exchange. 
+
+fmi3GetNumberOfEventIndicators must be called after a structural parameter is changed. As long as no structural parameters changed, the number of states is given in the modelDescription.xml, alleviating the need to call this function.
+"""
+function fmi3GetNumberOfEventIndicators!(cfunc::Ptr{Nothing}, c::fmi3Instance, nEventIndicators::Ref{Csize_t})
+    ccall(cfunc,
+            fmi3Status,
+            (fmi3Instance, Ptr{Csize_t}),
+            c, nEventIndicators)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.3. State: Initialization Mode
+
+Return the states at the current time instant.
+
+This function must be called if fmi3UpdateDiscreteStates returned with valuesOfContinuousStatesChanged == fmi3True. Not allowed in Co-Simulation and Scheduled Execution.
+"""
+function fmi3GetContinuousStates!(cfunc::Ptr{Nothing}, c::fmi3Instance, nominals::Array{fmi3Float64}, nContinuousStates::Csize_t)
+    ccall(cfunc,
+            fmi3Status,
+            (fmi3Instance, Ptr{fmi3Float64}, Csize_t),
+            c, nominals, nContinuousStates)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.3. State: Initialization Mode
+
+Return the nominal values of the continuous states.
+
+If fmi3UpdateDiscreteStates returned with nominalsOfContinuousStatesChanged == fmi3True, then at least one nominal value of the states has changed and can be inquired with fmi3GetNominalsOfContinuousStates.
+Not allowed in Co-Simulation and Scheduled Execution.
+"""
+function fmi3GetNominalsOfContinuousStates!(cfunc::Ptr{Nothing}, c::fmi3Instance, x_nominal::Array{fmi3Float64}, nx::Csize_t)
+    status = ccall(cfunc,
+                    fmi3Status,
+                    (fmi3Instance, Ptr{fmi3Float64}, Csize_t),
+                    c, x_nominal, nx)
+end
+
+# TODO not testable not supported by FMU
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.3. State: Initialization Mode
+
+This function is called to trigger the evaluation of fdisc to compute the current values of discrete states from previous values. 
+The FMU signals the support of fmi3EvaluateDiscreteStates via the capability flag providesEvaluateDiscreteStates.
+"""
+function fmi3EvaluateDiscreteStates(cfunc::Ptr{Nothing}, c::fmi3Instance)
+    ccall(cfunc,
+            fmi3Status,
+            (fmi3Instance,),
+            c)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.5. State: Event Mode
+
+This function is called to signal a converged solution at the current super-dense time instant. fmi3UpdateDiscreteStates must be called at least once per super-dense time instant.
+"""
+function fmi3UpdateDiscreteStates(cfunc::Ptr{Nothing}, c::fmi3Instance, discreteStatesNeedUpdate::Ref{fmi3Boolean}, terminateSimulation::Ref{fmi3Boolean}, 
+                                    nominalsOfContinuousStatesChanged::Ref{fmi3Boolean}, valuesOfContinuousStatesChanged::Ref{fmi3Boolean},
+                                    nextEventTimeDefined::Ref{fmi3Boolean}, nextEventTime::Ref{fmi3Float64})
+    ccall(cfunc,
+            fmi3Status,
+            (fmi3Instance, Ptr{fmi3Boolean}, Ptr{fmi3Boolean}, Ptr{fmi3Boolean}, Ptr{fmi3Boolean}, Ptr{fmi3Boolean}, Ptr{fmi3Float64}),
+            c, discreteStatesNeedUpdate, terminateSimulation, nominalsOfContinuousStatesChanged, valuesOfContinuousStatesChanged, nextEventTimeDefined, nextEventTime)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.5. State: Event Mode
+
+The model enters Continuous-Time Mode and all discrete-time equations become inactive and all relations are “frozen”.
+This function has to be called when changing from Event Mode (after the global event iteration in Event Mode over all involved FMUs and other models has converged) into Continuous-Time Mode.
+"""
+function fmi3EnterContinuousTimeMode(cfunc::Ptr{Nothing}, c::fmi3Instance)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance,),
+          c)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 2.3.5. State: Event Mode
+
+This function must be called to change from Event Mode into Step Mode in Co-Simulation (see 4.2.).
+"""
+function fmi3EnterStepMode(cfunc::Ptr{Nothing}, c::fmi3Instance)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance,),
+          c)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 3.2.1. State: Continuous-Time Mode
+
+Set a new time instant and re-initialize caching of variables that depend on time, provided the newly provided time value is different to the previously set time value (variables that depend solely on constants or parameters need not to be newly computed in the sequel, but the previously computed values can be reused).
+"""
+function fmi3SetTime(cfunc::Ptr{Nothing}, c::fmi3Instance, time::fmi3Float64)
+    c.t = time
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, fmi3Float64),
+          c, time)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 3.2.1. State: Continuous-Time Mode
+
+Set a new (continuous) state vector and re-initialize caching of variables that depend on the states. Argument nx is the length of vector x and is provided for checking purposes
+"""
+function fmi3SetContinuousStates(cfunc::Ptr{Nothing}, c::fmi3Instance,
+                                 x::Array{fmi3Float64},
+                                 nx::Csize_t)
+    ccall(cfunc,
+         fmi3Status,
+         (fmi3Instance, Ptr{fmi3Float64}, Csize_t),
+         c, x, nx)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 3.2.1. State: Continuous-Time Mode
+
+Compute first-oder state derivatives at the current time instant and for the current states.
+"""
+function fmi3GetContinuousStateDerivatives(cfunc::Ptr{Nothing}, c::fmi3Instance,
+                            derivatives::Array{fmi3Float64},
+                            nx::Csize_t)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, Ptr{fmi3Float64}, Csize_t),
+          c, derivatives, nx)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 3.2.1. State: Continuous-Time Mode
+
+Compute event indicators at the current time instant and for the current states. EventIndicators signal Events by their sign change.
+"""
+function fmi3GetEventIndicators!(cfunc::Ptr{Nothing}, c::fmi3Instance, eventIndicators::Array{fmi3Float64}, ni::Csize_t)
+    status = ccall(cfunc,
+                    fmi3Status,
+                    (fmi3Instance, Ptr{fmi3Float64}, Csize_t),
+                    c, eventIndicators, ni)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 3.2.1. State: Continuous-Time Mode
+
+This function must be called by the environment after every completed step of the integrator provided the capability flag needsCompletedIntegratorStep = true.
+If enterEventMode == fmi3True, the event mode must be entered
+If terminateSimulation == fmi3True, the simulation shall be terminated
+"""
+function fmi3CompletedIntegratorStep!(cfunc::Ptr{Nothing}, c::fmi3Instance,
+                                      noSetFMUStatePriorToCurrentPoint::fmi3Boolean,
+                                      enterEventMode::Ref{fmi3Boolean},
+                                      terminateSimulation::Ref{fmi3Boolean})
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance, fmi3Boolean, Ptr{fmi3Boolean}, Ptr{fmi3Boolean}),
+          c, noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 3.2.1. State: Continuous-Time Mode
+
+The model enters Event Mode from the Continuous-Time Mode in ModelExchange oder Step Mode in CoSimulation and discrete-time equations may become active (and relations are not “frozen”).
+"""
+function fmi3EnterEventMode(cfunc::Ptr{Nothing}, c::fmi3Instance, stepEvent::fmi3Boolean, stateEvent::fmi3Boolean, rootsFound::Array{fmi3Int32}, nEventIndicators::Csize_t, timeEvent::fmi3Boolean)
+    ccall(cfunc,
+          fmi3Status,
+          (fmi3Instance,fmi3Boolean, fmi3Boolean, Ptr{fmi3Int32}, Csize_t, fmi3Boolean),
+          c, stepEvent, stateEvent, rootsFound, nEventIndicators, timeEvent)
+end
+
+"""
+Source: FMISpec3.0, Version D5ef1c1: 4.2.1. State: Step Mode
+
+The computation of a time step is started.
+"""
+function fmi3DoStep!(cfunc::Ptr{Nothing}, c::fmi3Instance, currentCommunicationPoint::fmi3Float64, communicationStepSize::fmi3Float64, noSetFMUStatePriorToCurrentPoint::fmi3Boolean,
+                    eventEncountered::Ref{fmi3Boolean}, terminateSimulation::Ref{fmi3Boolean}, earlyReturn::Ref{fmi3Boolean}, lastSuccessfulTime::Ref{fmi3Float64})
+    @assert cfunc != C_NULL ["fmi3DoStep(...): This FMU does not support fmi3DoStep, probably it's a ME-FMU with no CS-support?"]
+
+    ccall(cfunc, fmi3Status,
+          (fmi3Instance, fmi3Float64, fmi3Float64, fmi3Boolean, Ptr{fmi3Boolean}, Ptr{fmi3Boolean}, Ptr{fmi3Boolean}, Ptr{fmi3Float64}),
+          c, currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint, eventEncountered, terminateSimulation, earlyReturn, lastSuccessfulTime)
 end
 
 """ Overload the Base.show() function for custom printing of the fmi3ModelDescription"""
@@ -415,7 +1969,5 @@ Base.show(io::IO, desc::fmi3ModelDescription) = print(io,
 FMI version:     $(desc.fmiVersion)
 GUID:            $(desc.instantiationToken)
 Description:     $(desc.description)
-Co-Simulation:   $(desc.isCoSimulation)
-Model-Exchange:  $(desc.isModelExchange)
 Model variables: $(desc.modelVariables)"
 )

--- a/src/FMICore.jl
+++ b/src/FMICore.jl
@@ -19,6 +19,8 @@ The mutable struct representing an abstract (version unknown) FMU.
 abstract type FMU end
 abstract type FMUSolution end
 
+include("executionConfig.jl")
+
 include("FMI2_c.jl")
 include("FMI2.jl")
 
@@ -28,7 +30,7 @@ include("FMI3.jl")
 ### EXPORTING LISTS START ###
 
 export FMU
-export FMU2ExecutionConfiguration, FMU_EXECUTION_CONFIGURATION_RESET, FMU_EXECUTION_CONFIGURATION_NO_RESET, FMU_EXECUTION_CONFIGURATION_NO_FREEING
+export FMUExecutionConfiguration, FMU_EXECUTION_CONFIGURATION_RESET, FMU_EXECUTION_CONFIGURATION_NO_RESET, FMU_EXECUTION_CONFIGURATION_NO_FREEING
 
 # FMI2.jl
 export FMU2, FMU2Component, FMU2ComponentEnvironment, FMU2Solution, FMU2Event 
@@ -64,7 +66,6 @@ export fmi2ModelDescription
 export fmi2ComponentState, fmi2ComponentStateInstantiated, fmi2ComponentStateInitializationMode, fmi2ComponentStateEventMode, fmi2ComponentStateContinuousTimeMode, fmi2ComponentStateTerminated, fmi2ComponentStateError, fmi2ComponentStateFatal
 
 # functions 
-export fmi2CallbackLogger, fmi2CallbackAllocateMemory, fmi2CallbackFreeMemory, fmi2CallbackStepFinished
 export fmi2Instantiate, fmi2FreeInstance!, fmi2GetTypesPlatform, fmi2GetVersion
 export fmi2SetDebugLogging, fmi2SetupExperiment, fmi2EnterInitializationMode, fmi2ExitInitializationMode, fmi2Terminate, fmi2Reset
 export fmi2GetReal!, fmi2SetReal, fmi2GetInteger!, fmi2SetInteger, fmi2GetBoolean!, fmi2SetBoolean, fmi2GetString!, fmi2SetString
@@ -75,8 +76,15 @@ export fmi2SetTime, fmi2SetContinuousStates, fmi2EnterEventMode, fmi2NewDiscrete
 export fmi2GetDerivatives!, fmi2GetEventIndicators!, fmi2GetContinuousStates!, fmi2GetNominalsOfContinuousStates!
 
 # FMI3.jl
-export FMU3, FMU3Component
+export FMU3, FMU3Instance, FMU3InstanceEnvironment
 export fmi3StatusToString
+export fmi3CausalityToString, fmi3StringToCausality
+export fmi3VariabilityToString, fmi3StringToVariability
+export fmi3InitialToString, fmi3StringToInitial
+export fmi3TypeToString, fmi3StringToType
+export fmi3IntervalQualifierToString, fmi3StringToIntervalQualifier
+export fmi3DependencyKindToString, fmi3StringToDependencyKind
+export fmi3VariableNamingConventionToString, fmi3StringToVariableNamingConvention
 
 # FMI3_c.jl 
 
@@ -92,9 +100,27 @@ export fmi3Clock
 export fmi3IntervalQualifier, fmi3IntervalQualifierIntervalChanged, fmi3IntervalQualifierIntervalNotYetKnown, fmi3IntervalQualifierIntervalUnchanged
 export fmi3Char, fmi3String, fmi3Boolean, fmi3Binary, fmi3Float32, fmi3Float64, fmi3Int8, fmi3UInt8, fmi3Int16, fmi3UInt16, fmi3Int32, fmi3UInt32, fmi3Int64, fmi3UInt64, fmi3Byte, fmi3FMUState, fmi3InstanceEnvironment, fmi3Enum
 export fmi3DependencyKind, fmi3DependencyKindDependent, fmi3DependencyKindIndependent, fmi3DependencyKindConstant, fmi3DependencyKindTunable, fmi3DependencyKindDiscrete, fmi3DependencyKindFixed, fmi3DependencyKindGetVariableDependencies
+export fmi3VariableNamingConvention, fmi3VariableNamingConventionFlat, fmi3VariableNamingConventionStructured
+export fmi3VariableDependency
+export fmi3InstanceState, fmi3InstanceStateInstantiated, fmi3InstanceStateInitializationMode, fmi3InstanceStateEventMode, fmi3InstanceStateStepMode, fmi3InstanceStateClockActivationMode, fmi3InstanceStateContinuousTimeMode
+export fmi3ConfigurationMode, fmi3ReconfigurationMode, fmi3InstanceStateTerminated, fmi3InstanceStateError, fmi3InstanceStateFatal
 
 # functions 
-# ToDo 
+export fmi3InstantiateCoSimulation, fmi3InstantiateModelExchange, fmi3InstantiateScheduledExecution, fmi3FreeInstance!, fmi3GetVersion
+export fmi3SetDebugLogging, fmi3EnterInitializationMode, fmi3ExitInitializationMode, fmi3Terminate, fmi3Reset
+export fmi3GetFloat32!, fmi3SetFloat32, fmi3GetFloat64!, fmi3SetFloat64
+export fmi3GetInt8!, fmi3SetInt8, fmi3GetInt16!, fmi3SetInt16,fmi3GetInt32!, fmi3SetInt32, fmi3GetInt64!, fmi3SetInt64
+export fmi3GetUInt8!, fmi3SetUInt8, fmi3GetUInt16!, fmi3SetUInt16,fmi3GetUInt32!, fmi3SetUInt32, fmi3GetUInt64!, fmi3SetUInt64
+export fmi3GetBoolean!, fmi3SetBoolean, fmi3GetString!, fmi3SetString, fmi3GetBinary!, fmi3SetBinary, fmi3GetClock!, fmi3SetClock
+export fmi3GetFMUState!, fmi3SetFMUState, fmi3FreeFMUState!, fmi3SerializedFMUStateSize!, fmi3SerializeFMUState!, fmi3DeSerializeFMUState!
+export fmi3SetIntervalDecimal, fmi3SetIntervalFraction, fmi3GetIntervalDecimal!, fmi3GetIntervalFraction!, fmi3GetShiftDecimal!, fmi3GetShiftFraction!, fmi3ActivateModelPartition
+export fmi3GetNumberOfVariableDependencies!, fmi3GetVariableDependencies!
+export fmi3GetDirectionalDerivative!, fmi3GetAdjointDerivative!, fmi3GetOutputDerivatives!
+export fmi3EnterConfigurationMode, fmi3ExitConfigurationMode
+export fmi3GetNumberOfContinuousStates!, fmi3GetNumberOfEventIndicators!
+export fmi3DoStep!, fmi3EnterStepMode
+export fmi3SetTime, fmi3SetContinuousStates, fmi3EnterEventMode, fmi3UpdateDiscreteStates, fmi3EnterContinuousTimeMode, fmi3CompletedIntegratorStep!
+export fmi3GetContinuousStateDerivatives, fmi3GetEventIndicators!, fmi3GetContinuousStates!, fmi3GetNominalsOfContinuousStates!, fmi3EvaluateDiscreteStates
 
 ### EXPORTING LISTS END ###
 

--- a/src/executionConfig.jl
+++ b/src/executionConfig.jl
@@ -1,0 +1,88 @@
+#
+# Copyright (c) 2021 Tobias Thummerer, Lars Mikelsons, Josef Kircher
+# Licensed under the MIT license. See LICENSE file in the project root for details.
+#
+
+"""
+A mutable struct representing the excution configuration of a FMU.
+For FMUs that have issues with calls like `fmi2Reset` or `fmi2FreeInstance`, this is pretty useful.
+"""
+mutable struct FMUExecutionConfiguration 
+    terminate::Bool     # call fmi2Terminate before every training step / simulation
+    reset::Bool         # call fmi2Reset before every training step / simulation
+    setup::Bool         # call setup functions before every training step / simulation
+    instantiate::Bool   # call fmi2Instantiate before every training step / simulation
+    freeInstance::Bool  # call fmi2FreeInstance after every training step / simulation
+
+    loggingOn::Bool     # enable FMU logging
+
+    handleStateEvents::Bool                 # handle state events during simulation/training
+    handleTimeEvents::Bool                  # handle time events during simulation/training
+
+    assertOnError::Bool                     # wheter an exception is thrown if a fmi2XXX-command fails (>= fmi2StatusError)
+    assertOnWarning::Bool                   # wheter an exception is thrown if a fmi2XXX-command warns (>= fmi2StatusWarning)
+
+    autoTimeShift::Bool                     # wheter to shift all time-related functions for simulation intervals not starting at 0.0
+
+    sensealg                                # algorithm for sensitivity estimation over solve call
+    useComponentShadow::Bool                # whether FMU outputs/derivatives/jacobians should be cached for frule/rrule (useful for ForwardDiff)
+    rootSearchInterpolationPoints::UInt     # number of root search interpolation points
+    inPlace::Bool                           # whether faster in-place-fx should be used
+    useVectorCallbacks::Bool                # whether to vector (faster) or scalar (slower) callbacks
+
+    maxNewDiscreteStateCalls::UInt          # max calls for fmi2NewDiscreteStates before throwing an exception
+
+    function FMUExecutionConfiguration()
+        inst = new()
+
+        inst.terminate = true 
+        inst.reset = true
+        inst.setup = true
+        inst.instantiate = false 
+        inst.freeInstance = false
+
+        inst.loggingOn = false
+
+        inst.handleStateEvents = true
+        inst.handleTimeEvents = true
+
+        inst.assertOnError = false
+        inst.assertOnWarning = false
+
+        inst.autoTimeShift = true
+
+        inst.sensealg = nothing # auto
+        inst.useComponentShadow = false
+        inst.rootSearchInterpolationPoints = 100
+        inst.inPlace = true
+        inst.useVectorCallbacks = true
+
+        inst.maxNewDiscreteStateCalls = 100
+
+        return inst 
+    end
+end
+
+#FMU2ExecutionConfiguration = FMUExecutionConfiguration
+#FMU3ExecutionConfiguration = FMUExecutionConfiguration
+
+# default for a "healthy" FMU - this is the fastetst 
+FMU_EXECUTION_CONFIGURATION_RESET = FMUExecutionConfiguration()
+FMU_EXECUTION_CONFIGURATION_RESET.terminate = true
+FMU_EXECUTION_CONFIGURATION_RESET.reset = true
+FMU_EXECUTION_CONFIGURATION_RESET.instantiate = false
+FMU_EXECUTION_CONFIGURATION_RESET.freeInstance = false
+
+# if your FMU has a problem with "fmi2Reset" - this is default
+FMU_EXECUTION_CONFIGURATION_NO_RESET = FMUExecutionConfiguration() 
+FMU_EXECUTION_CONFIGURATION_NO_RESET.terminate = false
+FMU_EXECUTION_CONFIGURATION_NO_RESET.reset = false
+FMU_EXECUTION_CONFIGURATION_NO_RESET.instantiate = true
+FMU_EXECUTION_CONFIGURATION_NO_RESET.freeInstance = true
+
+# if your FMU has a problem with "fmi2Reset" and "fmi2FreeInstance" - this is for weak FMUs (but slower)
+FMU_EXECUTION_CONFIGURATION_NO_FREEING = FMUExecutionConfiguration() 
+FMU_EXECUTION_CONFIGURATION_NO_FREEING.terminate = false
+FMU_EXECUTION_CONFIGURATION_NO_FREEING.reset = false
+FMU_EXECUTION_CONFIGURATION_NO_FREEING.instantiate = true
+FMU_EXECUTION_CONFIGURATION_NO_FREEING.freeInstance = false


### PR DESCRIPTION
* modified executionConfig

* Refactor fmi3 (#12)

* added conversions for causality, initial,...

* Added TODOs

* Refactor Model Description parsing

* copy ccalls, replace return value with fmi3Status

* replace Ptr{Nothing} with fmi3Instance

* Update FMI3_c.jl

* added more conversion methods

* Update FMI3_c.jl

* expand export list

* add instantiation functions

* add Instance State

* Apply changes lost in merge

* WIP: works until simulation

* Update FMI3_c.jl

* added missing functions

* more refactoring

* fix merge problems

* Update FMI3.jl

* Update FMI3.jl

* add internal state

refactor to new package version

* merged executionConfigs

* fix

* fixed project.toml

* minor fix

Co-authored-by: JoKircher <79573182+JoKircher@users.noreply.github.com>